### PR TITLE
ci: use --rebase in dependabot auto-merge (repo is rebase-only)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
         id: meta
       - name: Auto-merge patch and minor updates
         if: steps.meta.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge "$PR_URL" --auto --squash
+        run: gh pr merge "$PR_URL" --auto --rebase
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The auto-merge workflow used `gh pr merge --auto --squash`, but this repo is **rebase-only** (squash + merge commits disabled). So every Dependabot auto-merge failed with `Squash merges are not allowed on this repository` — that's why dependency PRs (e.g. the lancedb bump) never auto-merged. Switches to `--rebase` to match the repo's actual merge settings.