### PR TITLE
ci: add CI workflow and fix pre-existing TypeScript build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      # Note: actions/setup-node "cache: pnpm" is intentionally omitted because
+      # this repo gitignores pnpm-lock.yaml (no committed lockfile), which makes
+      # the cache step fail with "Dependencies lock file is not found".
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install web-ui dependencies
+        run: pnpm --prefix web-ui install
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Unit tests
+        run: pnpm test:unit

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -253,7 +253,6 @@ export class DocumentParser {
       const pdf = await getDocument({
         data: new Uint8Array(buffer),
         useSystemFonts: true,
-        isEvalSupported: false,
       }).promise
 
       // Extract text with position information from each page

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
 
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "src/*": ["src/*"]


### PR DESCRIPTION
## Summary

Adds a real CI workflow and fixes two pre-existing TypeScript errors that previously broke `tsc`/`build`, so the pipeline is green.

### CI workflow (`.github/workflows/ci.yml`)
- Triggers: `pull_request`, `push` to `main`, `workflow_dispatch`
- `permissions: contents: read`
- One job, id **`verify`** (check context = `verify`), `runs-on: ubuntu-latest`, `timeout-minutes: 15`
- Steps: checkout@v5, pnpm/action-setup@v4 (pnpm 10), setup-node@v5 (Node 24), `pnpm install`, `pnpm --prefix web-ui install`, then `pnpm type-check`, `pnpm lint`, `pnpm build`, `pnpm test:unit`

### Pre-existing fixes
1. **`tsconfig.json`** — added `"ignoreDeprecations": "6.0"` to silence `TS5101` for the deprecated `baseUrl` option (TS6 deprecates it ahead of removal in 7.0). Unblocks `tsc --noEmit` and `build`.
2. **`src/parser/index.ts`** — removed the obsolete `isEvalSupported: false` option from `getDocument()` (`TS2353`). `pdfjs-dist@5.7.284` removed `isEvalSupported` from `DocumentInitParameters` **and** from its runtime code (modern pdf.js no longer uses `eval`), so removing it is the correct minimal fix with no runtime behavior change.

### Notes / deviations
- The repo **gitignores `pnpm-lock.yaml`**, so the workflow uses plain `pnpm install` (no `--frozen-lockfile`) and omits `cache: pnpm` (which hard-fails without a committed lockfile). This matches the repo's prior CI convention (pnpm 10, `pnpm install`).
- pnpm **10** is used (not 11) because pnpm 11 stopped reading the `pnpm.onlyBuiltDependencies` field from `package.json`, which would otherwise break native dep builds (esbuild/onnxruntime/sharp).

### Local verification (pnpm 10, Node 24, `CI=true`)
- `pnpm install` — pass
- `pnpm --prefix web-ui install` — pass
- `pnpm type-check` — pass
- `pnpm lint` — pass (80 files, no errors)
- `pnpm build` — pass
- `pnpm test:unit` — 539/548 tests pass. The only 9 failures are all in `src/vectordb/__tests__/vectordb.test.ts` with LanceDB `os error 3` (Windows long-path IO). These are environmental to the local Windows machine and do not occur on `ubuntu-latest`.

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi