### PR TITLE
ci: modernize tsconfig (remove deprecated baseUrl + ignoreDeprecations band-aid)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,6 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
 
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
-    "paths": {
-      "src/*": ["src/*"]
-    },
-
     "outDir": "./dist",
     "rootDir": "./src",
     "sourceMap": true,


### PR DESCRIPTION
## What

Properly modernizes the root `tsconfig.json` by **migrating the deprecated TypeScript options instead of silencing them**. A prior change added `"ignoreDeprecations": "6.0"` to mute `TS5101: 'baseUrl' is deprecated`. That is a band-aid — TypeScript 7 will **remove** `baseUrl` entirely — so this PR fixes the underlying cause and removes the silencer.

## Changes (`tsconfig.json` only)

| Removed | Why |
|---|---|
| `"ignoreDeprecations": "6.0"` | Band-aid no longer needed — nothing is being silenced. |
| `"baseUrl": "."` | Deprecated (TS5101); removed entirely. |
| `"paths": { "src/*": ["src/*"] }` | **Dead config.** Zero source files import via `src/*` (every bare import is a real npm package or `node:` builtin). After removing `baseUrl`, a `paths` entry with a non-relative target would itself error (`TS5090: Non-relative paths are not allowed when 'baseUrl' is not set`), so the correct fix is to drop the unused alias rather than rewrite it. |

`moduleResolution` is left as `NodeNext` — it is **not** deprecated (the deprecated values are `node10`/`node`/`classic`, which this repo never used), so `TS5107` never applied here.

## Verification (local, with the repo's pinned `typescript@6.0.3`)

- `pnpm type-check` — **clean**, no `TS5101` / `TS5107` / `TS5090`, nothing silenced.
- `pnpm lint` — clean (80 files).
- `pnpm build` — green. `dist/` structure unchanged; built imports resolve (relative `./*.js` specifiers; `tsc-alias` has nothing to rewrite since the alias was unused). Built entrypoint boots.
- `pnpm test:unit` — 539 passing. The only 9 failures are all in `src/vectordb/__tests__/vectordb.test.ts`, caused by the Windows-only lancedb `os error 3` long-path issue (environmental, unrelated to this change; passes on the Linux CI runner).

`ignoreDeprecations` is **gone** and `tsc` is clean without it.

Claude-Session: https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi